### PR TITLE
Assignment - 1 1/26/24

### DIFF
--- a/Assignment_1 (1).js
+++ b/Assignment_1 (1).js
@@ -1,0 +1,59 @@
+/Text Index/
+db.student.createIndex({name: "text", description: "text"},
+{
+"createdCollectionAutomatically" : false,
+"numIndexesBefore" : 1,
+"numIndexsAfter" : 2,
+"ok": 1
+})
+  then give db.student.getindexes()
+/*o/p 
+[
+  { v: 2, key: { id: 1 }, name: '_id' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' },
+  { v: 2, key: { student_id: 777777 }, name: 'student_id_777777' },
+  { v: 2, key: { student_id: 1 }, name: 'student_id_1' },
+  {
+    v: 2,
+    key: { score: '2dsphere' },
+    name: 'score_2dsphere',
+    '2dsphereIndexVersion': 3
+  },
+  {
+    v: 2,
+    key: { _fts: 'text', _ftsx: 1 },
+    name: 'name_text_description_text',
+    weights: { description: 1, name: 1 },
+    default_language: 'english',
+    language_override: 'language',
+    textIndexVersion: 3
+  }
+] 
+*/
+    //HashIndex
+db.student.createIndex({_id: "hashed"})
+>_id_hashed
+db.student.getIndexes()
+/*o/p:
+[
+  { v: 2, key: { id: 1 }, name: '_id' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' },
+  { v: 2, key: { student_id: 777777 }, name: 'student_id_777777' },
+  { v: 2, key: { student_id: 1 }, name: 'student_id_1' },
+  {
+    v: 2,
+    key: { score: '2dsphere' },
+    name: 'score_2dsphere',
+    '2dsphereIndexVersion': 3
+  },
+  {
+    v: 2,
+    key: { _fts: 'text', _ftsx: 1 },
+    name: 'name_text_description_text',
+    weights: { description: 1, name: 1 },
+    default_language: 'english',
+    language_override: 'language',
+    textIndexVersion: 3
+  },
+  { v: 2, key: { _id: 'hashed' }, name: '_id_hashed' }
+]*/


### PR DESCRIPTION
Text Index: MongoDB supports query operations that perform a text search of string content. Text indexing allows us to find the string content in the specified collection. It can include any field that contains string content or an array of string items. A collection can contain, at most, one text index. You are allowed to use the text index in the compound index.
Syntax: db..createIndex( { : “text”} )
![text index](https://github.com/JyothiThumma/Abv-database-/assets/157539504/e68e1c55-3f84-4981-bc42-4aebae2aaa48)





MultiKey Index: MongoDB uses the multikey indexes to index the values stored in arrays. When we index a field that holds an array value then MongoDB automatically creates a separate index of each and every value present in that array. Using these multikey indexes we can easily find a document that contains an array by matching the items. In MongoDB, you don’t need to explicitly specify the multikey index because MongoDB automatically determines whether to create a multikey index if the indexed field contains an array value.
Syntax:db..createIndex( { : } )
![MultiKey Index](https://github.com/JyothiThumma/Abv-database-/assets/157539504/17d9e46f-a35a-48b1-a7ed-fc146a0f46da)



Hash Index: To maintain the entries with hashes of the values of the indexed field (mostly the _id field in all collections), we use the hash index. This kind of index is mainly required for the even distribution of data via sharing. Hashed keys help partition the data across the shared cluster.
Syntax: db..createIndex( { _id: “hashed” } )
![Hash Index](https://github.com/JyothiThumma/Abv-database-/assets/157539504/1fe75003-3f84-474c-adf1-1168d225606d)



WildCard Index: MongoDB supports creating indexes either on a field or set of fields, and if the set of fields is mentioned, it is called a Wildcard Index. Generally, the wildcard index does not include the _id field, but if you want to include the _id field in the wildcard index, then you have to define it explicitly. MongoDB allows you to create multiple wildcard indexes in the given collection. Wildcard indexes support queries for unknown or arbitrary fields.
Syntax: db..createIndex( { “field.$**”:1 } )
![Hash Index](https://github.com/JyothiThumma/Abv-database-/assets/157539504/675ce619-5f15-4a5d-afba-c2ced4667c88)


